### PR TITLE
Took out redundant statement from travis.yml

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -9,5 +9,3 @@ env:
   - MIX_ENV=test ELIXIR_ERL_OPTIONS="+T 9"
 before_script:
   - mix do deps.get, compile --warnings-as-errors
-script:
-  - mix test


### PR DESCRIPTION
Do not need `mix test` if using defaults.